### PR TITLE
Bugfix: Allow author name row to expand if necessary

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -39,7 +39,7 @@
     display: grid;
     justify-items: start;
     grid-template-columns: 1fr;
-    grid-template-rows: 2rem minmax(6rem, 1fr) auto;
+    grid-template-rows: minmax(2rem, auto) minmax(6rem, 1fr) auto;
     min-height: 10em;
     padding-inline-start: 1.5rem;
     padding-inline-end: 3rem;


### PR DESCRIPTION
## Commit message

Some longer author names can wrap at some screen sizes. Having the first grid row's height fixed at 2rem means that if the author name wraps then it overlaps the title. Treating 2rem as the minimum height instead allows the row to expand, pushing down the title where necessary.

## Screenshot

_Before:_
![image](https://github.com/user-attachments/assets/a03748eb-82bb-46c1-934e-54dc1188147e)

_After:_
![image](https://github.com/user-attachments/assets/a15c06e7-de96-4720-a122-3321ded17095)

Note that this is just a quick fix - the line-height and spacing aren't perfect when the text wraps, but this change at least fixes the immediate issue (I _think_ it should address #1 too).