### PR TITLE
Adaptable author row size

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -39,7 +39,7 @@
     display: grid;
     justify-items: start;
     grid-template-columns: 1fr;
-    grid-template-rows: 2rem minmax(6rem, 1fr) auto;
+    grid-template-rows: min-content minmax(6rem, 1fr) auto;
     min-height: 10em;
     padding-inline-start: 1.5rem;
     padding-inline-end: 3rem;


### PR DESCRIPTION
The previous styles caused overlap when the author line wrapped (see No. 18 at mobile sizes).  The change from `2rem` to `min-content` prevents this overlap.