### PR TITLE
add lost book: approachable open source

### DIFF
--- a/src/components/book-card.astro
+++ b/src/components/book-card.astro
@@ -32,7 +32,9 @@ if (data.number) {
 const numberClasses = twMerge(
   "book-number absolute top-[-1.75rem] right-4 sm:right-2 text-[2rem]/none text-white rounded-full bg-black inline-flex flex-col items-center justify-center w-[1.75em] h-[1.75em]",
   collection === "briefs" &&
-    "rounded-lg text-[1.75rem]/none w-auto h-auto py-1 px-2"
+    "rounded-lg text-[1.75rem]/none w-auto h-auto py-1 px-2",
+  collection === "lost" && 
+    "rounded-none transform rotate-45"
 );
 ---
 
@@ -44,11 +46,15 @@ const numberClasses = twMerge(
   style={`--book-color: ${color}`}>
   <div class:list={numberClasses}>
     {
-      collection === "briefs" && (
+      (collection === "briefs" && (
         <span class="text-xs uppercase font-semibold tracking-wider">
           Briefs
         </span>
-      )
+      )) || (collection === "lost" && (
+        <span class="text-xs uppercase font-semibold tracking-wider transform -rotate-45">
+          Lost
+        </span>
+      ))
     }
     <span class="font-serif font-semibold tracking-tighter text-center -ml-px"
       >{bookNumber}</span

--- a/src/content/authors/brian-muenzenmeyer.md
+++ b/src/content/authors/brian-muenzenmeyer.md
@@ -1,0 +1,3 @@
+---
+name: Brian Muenzenmeyer
+---

--- a/src/content/books/lost-approachable-open-source.md
+++ b/src/content/books/lost-approachable-open-source.md
@@ -4,7 +4,7 @@ number: 0
 title: Approachable Open Source
 author: brian-muenzenmeyer
 url: https://approachableopensource.com
-color: "#000"
+color: "#444"
 isbn: 979-8-9907798-0-8
 pages: 190
 published: 2024-08-27

--- a/src/content/books/lost-approachable-open-source.md
+++ b/src/content/books/lost-approachable-open-source.md
@@ -1,0 +1,11 @@
+---
+collection: lost
+number: 0
+title: Approachable Open Source
+author: brian-muenzenmeyer
+url: https://approachableopensource.com
+color: "#000"
+isbn: 979-8-9907798-0-8
+pages: 190
+published: 2024-08-27
+---

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -16,7 +16,7 @@ const authors = defineCollection({
 const books = defineCollection({
   type: 'content',
   schema: z.object({
-    collection: z.enum(['briefs', 'books']).default('books'),
+    collection: z.enum(['briefs', 'books', 'lost']).default('books'),
     number: z.number().optional(),
     title: z.string(),
     author: reference('authors'),


### PR DESCRIPTION
I found out about this wonderful project on an internal discord that some of the ABA authors hang out in. 

There are 5 to 7 folks (myself included) cut loose from ABA prior to publish. I think...maybe 3 will see the light of day. Would you be amenable to adding them too?

We got accepted, we put in the work, we just ran outta time.

![image](https://github.com/user-attachments/assets/29bce3a3-3efa-41a6-aa52-96f77f7550bc)


This PR adds a new category: `lost`. 

- It automatically displays at the end, thanks to the alphabetical nature of the collections.
- It differentiates itself visually from a book and a brief, using TW rotate to make a diamond.
- It does not display a number, since we didn't get one.
- ~~It uses BLACK - which is perhaps presumptuous. But it seems sorta fitting. ABA cover color was a significant part of the process for the author.~~
- ~~the black does not interfere with the awesome gradient on the site.~~